### PR TITLE
Added transient cache clear command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 [![Build Status](https://travis-ci.org/paulbunyannet/wordpress-artisan.svg?branch=master)](https://travis-ci.org/paulbunyannet/wordpress-artisan)
 
     wp
-        wp:down              Put Wordpress in maintenance mode
-        wp:keys              Generate Wordpress Authentication keys
-        wp:up                Bring Wordpress back out of maintenance mode 
+        wp:down                   Put Wordpress in maintenance mode
+        wp:keys                   Generate Wordpress Authentication keys
+        wp:up                     Bring Wordpress back out of maintenance mode
+        wp:clear-transient-cache  Clear all the transient caches from the database
 
 ## Config
 
-Run `php artisan vendor:publish --provider="Pbc\WordpressArtisan\WordpressArtisanServiceProvider" --tag="config"` to get the configuration file and then update as needed.
+Run `php artisan vendor:publish --provider="Pbc\WordpressArtisan\WordpressArtisanServiceProvider" --tag="config" --tag="lang"` to get the configuration and language files and then update as needed.
 
 ## Commands
 
@@ -30,6 +31,14 @@ Builds Wordpress authentication keys and applies them to the .env file, similar 
 #### Usage
 
 `php artisan wp:keys` to generate new keys
+
+### Wordpress Clear Transient Cache
+
+Clear all the transient caches from the database. Requires https://github.com/corcel/corcel to be installed and configured.
+
+#### Usage
+
+`php artisan wp:clear-transient-cache` to clear the transient caches from the database
 
 ## Roadmap
 

--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,8 @@
     "test": [
       ""
     ]
-  }
+  },
+    "suggest": {
+        "jgrossi/corcel": "Needed for using wp:clear-cache command. See https://github.com/corcel/corcel for instructions."
+    }
 }

--- a/resources/lang/en/pbc/wordpressartisan/commands/wordpress/cleartransientcache.php
+++ b/resources/lang/en/pbc/wordpressartisan/commands/wordpress/cleartransientcache.php
@@ -1,0 +1,13 @@
+<?php
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Wordpress Clear Transient Cache Language
+    |--------------------------------------------------------------------------
+    |
+    | Language lines used int he wp:clear-transient-cache command
+    |
+    */
+    'error' => 'There are still transients in the Wordpress cache, expected 0 but got :count',
+    'success' => 'Wordpress transient cache cleared!',
+];

--- a/src/Commands/Wordpress/Cache/ClearTransientCache.php
+++ b/src/Commands/Wordpress/Cache/ClearTransientCache.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Pbc\WordpressArtisan\Commands\Wordpress\Cache;
+
+use Corcel\Model\Option;
+use Illuminate\Console\Command;
+use Pbc\WordpressArtisan\Helpers;
+
+/**
+ * Class CallRoute
+ * @package App\Console\Commands
+ */
+class ClearTransientCache extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'wp:clear-transient-cache';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clear Wordpress transient cache';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $clear = $this->clearTransients();
+        if($clear !== 0) {
+            $this->error(Helpers::getLang(get_class($this), 'error', ['count' => $clear]));
+            return;
+        }
+        $this->info(Helpers::getLang(get_class($this), 'success', []));
+        return;
+    }
+
+    /**
+     * Clear the transients and check that they are all gone
+     * @return integer
+     */
+    protected function clearTransients()
+    {
+        // https://coderwall.com/p/yrqrkw/delete-all-existing-wordpress-transients-in-mysql-database
+        // DELETE FROM `wp_options` WHERE `option_name` LIKE ('_transient_%');
+        // DELETE FROM `wp_options` WHERE `option_name` LIKE ('_site_transient_%');
+        Option::where('option_name', 'like', '_transient_%')->delete();
+        Option::where('option_name', 'like', '_site_transient_%')->delete();
+        return Option::where('option_name', 'like', '%_transient_%')->count();
+    }
+}

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Pbc\WordpressArtisan;
+
+
+class Helpers
+{
+
+    /**
+     * Get a language key using the class name as a base for the translation file
+     * @param $class
+     * @param $key
+     * @param array $params
+     * @return string|\Symfony\Component\Translation\TranslatorInterface
+     */
+    public static function getLang($class, $key, $params = [])
+    {
+        return trans((strtolower(str_replace('\\', '/', $class) . '.' . $key)), $params);
+    }
+
+}

--- a/src/WordpressArtisanServiceProvider.php
+++ b/src/WordpressArtisanServiceProvider.php
@@ -25,7 +25,7 @@ class WordpressArtisanServiceProvider extends ServiceProvider
         ], 'config');
 
         $this->publishes([
-            __DIR__ . '/../resources/lang/en/pbc/wordpressartisan/commands/wordpress/cleartransientcache.php' => resource_path('lang/pbc/wordpressartisan/commands/wordpress/cache/cleartransientcache'),
+            __DIR__ . '/../resources/lang/en/pbc/wordpressartisan/commands/wordpress/cleartransientcache.php' => resource_path('lang/pbc/wordpressartisan/commands/wordpress/cache/cleartransientcache.php'),
         ]);
     }
 

--- a/src/WordpressArtisanServiceProvider.php
+++ b/src/WordpressArtisanServiceProvider.php
@@ -25,7 +25,7 @@ class WordpressArtisanServiceProvider extends ServiceProvider
         ], 'config');
 
         $this->publishes([
-            __DIR__ . '/../resources/lang/en/pbc/wordpressartisan/commands/wordpress/cleartransientcache.php' => resource_path('lang/pbc/wordpressartisan/commands/wordpress/cache/cleartransientcache.php'),
+            __DIR__ . '/../resources/lang/en/pbc/wordpressartisan/commands/wordpress/cleartransientcache.php' => resource_path('lang/en/pbc/wordpressartisan/commands/wordpress/cache/cleartransientcache.php'),
         ]);
     }
 

--- a/src/WordpressArtisanServiceProvider.php
+++ b/src/WordpressArtisanServiceProvider.php
@@ -22,7 +22,7 @@ class WordpressArtisanServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__ . '/../resources/lang/en/pbc/wordpressartisan/commands/wordpress/cleartransientcache.php' => resource_path('lang/en/pbc/wordpressartisan/commands/wordpress/cache/cleartransientcache.php'),
-        ]);
+        ], 'lang');
     }
 
     public function register()

--- a/src/WordpressArtisanServiceProvider.php
+++ b/src/WordpressArtisanServiceProvider.php
@@ -3,6 +3,10 @@ namespace Pbc\WordpressArtisan;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Filesystem\Filesystem;
+use Pbc\WordpressArtisan\Commands\Wordpress\Cache\ClearTransientCache;
+use Pbc\WordpressArtisan\Commands\Wordpress\Maintenance\Down;
+use Pbc\WordpressArtisan\Commands\Wordpress\Maintenance\Up;
+use Pbc\WordpressArtisan\Commands\Wordpress\SecretKey\Create;
 
 /**
  * Class ArtisanWordpressServiceProvider
@@ -19,6 +23,10 @@ class WordpressArtisanServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../config/wordpress-artisan.php' => config_path('wordpress-artisan.php'),
         ], 'config');
+
+        $this->publishes([
+            __DIR__ . '/../resources/lang/en/pbc/wordpressartisan/commands/wordpress/cleartransientcache.php' => resource_path('lang/pbc/wordpressartisan/commands/wordpress/cache/cleartransientcache'),
+        ]);
     }
 
     public function register()
@@ -33,9 +41,10 @@ class WordpressArtisanServiceProvider extends ServiceProvider
         });
         
         $this->commands([
-            \Pbc\WordpressArtisan\Commands\Wordpress\Maintenance\Up::class,
-            \Pbc\WordpressArtisan\Commands\Wordpress\Maintenance\Down::class,
-            \Pbc\WordpressArtisan\Commands\Wordpress\SecretKey\Create::class,
+            Up::class,
+            Down::class,
+            Create::class,
+            ClearTransientCache::class,
         ]);
     }
 }

--- a/src/WordpressArtisanServiceProvider.php
+++ b/src/WordpressArtisanServiceProvider.php
@@ -3,10 +3,6 @@ namespace Pbc\WordpressArtisan;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Filesystem\Filesystem;
-use Pbc\WordpressArtisan\Commands\Wordpress\Cache\ClearTransientCache;
-use Pbc\WordpressArtisan\Commands\Wordpress\Maintenance\Down;
-use Pbc\WordpressArtisan\Commands\Wordpress\Maintenance\Up;
-use Pbc\WordpressArtisan\Commands\Wordpress\SecretKey\Create;
 
 /**
  * Class ArtisanWordpressServiceProvider
@@ -41,10 +37,10 @@ class WordpressArtisanServiceProvider extends ServiceProvider
         });
         
         $this->commands([
-            Up::class,
-            Down::class,
-            Create::class,
-            ClearTransientCache::class,
+            \Pbc\WordpressArtisan\Commands\Wordpress\Maintenance\Up::class,
+            \Pbc\WordpressArtisan\Commands\Wordpress\Maintenance\Down::class,
+            \Pbc\WordpressArtisan\Commands\Wordpress\SecretKey\Create::class,
+            \Pbc\WordpressArtisan\Commands\Wordpress\Cache\ClearTransientCache::class,
         ]);
     }
 }


### PR DESCRIPTION
Added the command `wp:clear-transient-cache` to the mix. This will clear all the transient caches in the WP `options` table like https://coderwall.com/p/yrqrkw/delete-all-existing-wordpress-transients-in-mysql-database.